### PR TITLE
Stop sending bowler email address to Stripe.

### DIFF
--- a/app/controllers/bowlers_controller.rb
+++ b/app/controllers/bowlers_controller.rb
@@ -401,8 +401,6 @@ class BowlersController < ApplicationController
       cancel_url: "#{client_host}/bowlers/#{bowler.identifier}",
       line_items: line_items,
       mode: 'payment',
-      customer_email: bowler.email,
-      customer_creation: 'always',
       submit_type: 'pay',
     }
 
@@ -418,7 +416,7 @@ class BowlersController < ApplicationController
       },
     )
   rescue Stripe::StripeError => e
-    Rails.logger.info "Stripe error: #{e}"
+    Rails.logger.warn "Stripe error: #{e}"
     Bugsnag.notify(e)
   end
 


### PR DESCRIPTION
Bowler or person making the payment will need to provide it instead.