### PR TITLE
Add tests to cover the case where a bowler joins an empty team

### DIFF
--- a/app/blueprints/bowler_blueprint.rb
+++ b/app/blueprints/bowler_blueprint.rb
@@ -8,12 +8,14 @@ class BowlerBlueprint < Blueprinter::Base
   field :full_name do |b, _|
     TournamentRegistration.person_display_name(b.person)
   end
-
-  association :tournament, blueprint: TournamentBlueprint
-
   field :amount_due do |b, _|
     TournamentRegistration.amount_due(b).to_i
   end
+  field :doubles_partner_name do |b, _|
+    b.doubles_partner.present? ? TournamentRegistration.person_display_name(b.doubles_partner.person) : 'n/a'
+  end
+
+  association :tournament, blueprint: TournamentBlueprint
 
   view :list do
     association :events, blueprint: PurchaseBlueprint do |bowler, _|

--- a/spec/requests/bowlers_spec.rb
+++ b/spec/requests/bowlers_spec.rb
@@ -110,8 +110,6 @@ describe BowlersController, type: :request do
           end
 
           context 'a team on a shift' do
-            let(:shift) { tournament.shifts.first }
-
             let(:bowler_params) do
               {
                 bowlers: [
@@ -138,6 +136,29 @@ describe BowlersController, type: :request do
               expect { subject }.not_to change { shift.reload.confirmed }
             end
           end
+
+          context 'a team with zero bowlers' do
+            let(:bowler_params) do
+              {
+                bowlers: [
+                  create_bowler_test_data.merge({ position: 1, shift_identifier: shift.identifier })
+                ]
+              }
+            end
+
+            it 'creates a BowlerShift instance' do
+              expect { subject }.to change(BowlerShift, :count).by(1)
+            end
+
+            it 'bumps the requested count by one' do
+              expect { subject }.to change { shift.reload.requested }.by(1)
+            end
+
+            it 'does not bump the confirmed count' do
+              expect { subject }.not_to change { shift.reload.confirmed }
+            end
+          end
+
         end
 
         context 'with a full team' do

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -447,7 +447,6 @@ module ApiHelpers
           'response' => 'I like pizza!',
         },
       ],
-      'shift_identifier' => 'this-is-a-shift',
     }
   end
 


### PR DESCRIPTION
And add doubles partner name to the default bowler blueprint.